### PR TITLE
Switch to Resolve Ecoregion Name, Include Baileys Ecoregion

### DIFF
--- a/helpers/land_use.py
+++ b/helpers/land_use.py
@@ -57,7 +57,7 @@ def get_land_use(longitude, latitude):
         return f"Error retrieving land cover data: {e}"
 
 
-def get_ecosystem(longitude, latitude):
+def get_resolve_ecoregion(longitude, latitude):
     # Load the WWF Terrestrial Ecoregions dataset
     ecoregions = ee.FeatureCollection("RESOLVE/ECOREGIONS/2017")
 
@@ -67,9 +67,26 @@ def get_ecosystem(longitude, latitude):
     # Filter the dataset to find the ecoregion at the given point
     ecoregion_info = ecoregions.filterBounds(point).first()
 
-    # Retrieve the biome name
+    # Retrieve the ecoregion name (finest classification)
     try:
-        biome_name = ecoregion_info.get("BIOME_NAME").getInfo()
+        biome_name = ecoregion_info.get("ECO_NAME").getInfo()
+        return biome_name
+    except Exception as e:
+        return f"Error retrieving biome data: {e}"
+
+def get_baileys_ecoregion(longitude, latitude):
+    # Load the UNEP-WCMC Baileys Ecoregions of the World dataset
+    ecoregions = ee.FeatureCollection("projects/spun-geospatial/assets/baileysEcoregions")
+
+    # Define the point geometry for the specified coordinates
+    point = ee.Geometry.Point([longitude, latitude])
+
+    # Filter the dataset to find the ecoregion at the given point
+    ecoregion_info = ecoregions.filterBounds(point).first()
+
+    # Retrieve the province description (finest classification)
+    try:
+        biome_name = ecoregion_info.get("pro_desc").getInfo()
         return biome_name
     except Exception as e:
         return f"Error retrieving biome data: {e}"

--- a/models/sequencing_sample.py
+++ b/models/sequencing_sample.py
@@ -1,6 +1,6 @@
 import logging
 from helpers.dbm import connect_db, get_session
-from helpers.land_use import get_land_use, get_ecosystem, get_elevation
+from helpers.land_use import get_land_use, get_resolve_ecoregion, get_baileys_ecoregion, get_elevation
 from models.db_model import SequencingSamplesTable
 from sqlalchemy import or_
 
@@ -122,8 +122,10 @@ class SequencingSample:
                     SequencingSamplesTable.Elevation == "",
                     SequencingSamplesTable.Land_use.is_(None),
                     SequencingSamplesTable.Land_use == "",
-                    SequencingSamplesTable.Ecosystem.is_(None),
-                    SequencingSamplesTable.Ecosystem == "",
+                    SequencingSamplesTable.ResolveEcoregion.is_(None),
+                    SequencingSamplesTable.ResolveEcoregion == "",
+                    SequencingSamplesTable.BaileysEcoregion.is_(None),
+                    SequencingSamplesTable.BaileysEcoregion == "",
                 ),
                 # Ensuring Latitude and Longitude are valid
                 # and not empty or 'nan'
@@ -162,7 +164,7 @@ class SequencingSample:
                         continue
 
                     # Proceed with getting the missing fields
-                    # (Land_use, Ecosystem, Elevation)
+                    # (Land_use, ResolveEcoregion, BaileysEcoregion, Elevation)
                     if not sample.Land_use:
                         land_use = get_land_use(longitude, latitude)
                         if land_use:
@@ -172,13 +174,22 @@ class SequencingSample:
                                 f" {sample.SampleID} with {land_use}"
                             )
 
-                    if not sample.Ecosystem:
-                        ecosystem = get_ecosystem(longitude, latitude)
-                        if ecosystem:
-                            sample.Ecosystem = ecosystem
+                    if not sample.ResolveEcoregion:
+                        ecoregion = get_resolve_ecoregion(longitude, latitude)
+                        if ecoregion:
+                            sample.ResolveEcoregion = ecoregion
                             logger.info(
-                                f"Updated Ecosystem for SampleID"
-                                f" {sample.SampleID} with {ecosystem}"
+                                f"Updated Resolve Ecoregion for SampleID"
+                                f" {sample.SampleID} with {ecoregion}"
+                            )
+
+                    if not sample.BaileysEcoregion:
+                        ecoregion = get_baileys_ecoregion(longitude, latitude)
+                        if ecoregion:
+                            sample.BaileysEcoregion = ecoregion
+                            logger.info(
+                                f"Updated Resolve Ecoregion for SampleID"
+                                f" {sample.SampleID} with {ecoregion}"
                             )
 
                     if not sample.Elevation:

--- a/views/metadata.py
+++ b/views/metadata.py
@@ -1473,7 +1473,8 @@ def update_missing_geo_data():
 
     SequencingSample.update_missing_fields()
     # land_use = get_land_use(-122.4194, 37.7749)
-    # ecosystem = get_ecosystem(-122.4194, 37.7749)
+    # resolve_ecoregion = get_resolve_ecoregion(-122.4194, 37.7749)
+    # baileys_ecoregion = get_baileys_ecoregion(-122.4194, 37.7749)
     # elevation = get_elevation(-122.4194, 37.7749)
     return jsonify({"done": 1}), 200
 


### PR DESCRIPTION
This PR would require an adjustment in the schema to make space for another ecoregions dataset. We currently use both baileys and resolve ecoregions for various analyses further down. 

For the resolve ecoregions: 
I've changed the column to be "ECO_NAME" which are descriptions of the finest level of classification available in the resolve dataset. I thought it would be better to use this finer class, but I do know that other members of the science team are more interested in the biome level stuff so I'm not quite sure what the final say on this is. 

For the baileys ecoregions: 
I've included a pointer to a SPUN hosted GEE asset called baileysEcoregions where we pull out the provision description ("pro_desc"). 

Baileys Ecoregions: https://data-gis.unep-wcmc.org/portal/home/item.html?id=1d5d46888b1e4fb19c45042de1e576b2