### PR TITLE
Fix app startup and DB/Flask race condition in dev compose

### DIFF
--- a/docker-compose-dev-mac.yml
+++ b/docker-compose-dev-mac.yml
@@ -40,7 +40,7 @@ services:
       - DOCKER_HOST=tcp://socat:2375  # Set Docker host to socat
     networks:
       - flask
-    command: ["alembic", "upgrade", "head"]
+    command: ["sh", "-c", "sleep 5 && alembic upgrade head && python app.py"]
 
   celery-worker:
     container_name: spun-celery-worker  # Unique name for the Celery worker container

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -24,7 +24,7 @@ services:
       - GUNICORN_WORKERS=1
     networks:
       - flask
-    command: ["alembic", "upgrade", "head"]
+    command: ["sh", "-c", "sleep 5 && alembic upgrade head && python app.py"]
 
   celery-worker:
     container_name: spun-celery-worker  # Unique name for the Celery worker container


### PR DESCRIPTION
Changed the command for the flask service so that the app can run locally, avoiding a race condition and given an entry point for the app.